### PR TITLE
Adds basic starter CLI with click

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -940,7 +940,7 @@ packages:
 - pypi: .
   name: rmmd
   version: 1.0.0
-  sha256: d29d4492aded7cb52f8de2914753e4f498a18f3b10438a596caf69d740c0a6e2
+  sha256: 6cfc7d8e6b525a3e7503b986e5a594411ac60edd3510149eda9584eda75c09bb
   requires_dist:
   - pydantic>=2.10.0,<3
   - pyyaml>=5.4.1,<7

--- a/pixi.lock
+++ b/pixi.lock
@@ -30,6 +30,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
@@ -70,6 +71,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/f1/6f2ee3f991327ad9e4c2f8b82611a467052a0fb0e247390192580e89f7ff/debugpy-1.8.14-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
@@ -174,6 +176,14 @@ packages:
   purls: []
   size: 158834
   timestamp: 1745260472197
+- pypi: https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl
+  name: click
+  version: 8.1.8
+  sha256: 63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2
+  requires_dist:
+  - colorama ; sys_platform == 'win32'
+  - importlib-metadata ; python_full_version < '3.8'
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl
   name: comm
   version: 0.2.2
@@ -930,11 +940,12 @@ packages:
 - pypi: .
   name: rmmd
   version: 1.0.0
-  sha256: 1ad6156dfa4e7ed11af315c44ce7a3d9277f87a7ae02302d346914ca4e7b4b2f
+  sha256: d29d4492aded7cb52f8de2914753e4f498a18f3b10438a596caf69d740c0a6e2
   requires_dist:
   - pydantic>=2.10.0,<3
   - pyyaml>=5.4.1,<7
   - pytest>=8.0,<9
+  - click>=8.1.8,<9
   requires_python: '>=3.11'
   editable: true
 - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ authors = [{name = "Andreas Copan", email = "avcopan@gmail.com"}]
 dependencies = [
     "pydantic>=2.10.0,<3",
     "pyyaml>=5.4.1,<7",
-    "pytest>=8.0,<9"
+    "pytest>=8.0,<9",
+    "click>=8.1.8,<9",
 ]
 description = "Add a short description here"
 name = "rmmd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ version = "1.0.0"
 build-backend = "hatchling.build"
 requires = ["hatchling"]
 
+[project.scripts]
+rmmd = "rmmd.cli:rmmd"
+
 [tool.pixi.project]
 channels = ["conda-forge"]
 platforms = ["linux-64"]

--- a/src/rmmd/cli.py
+++ b/src/rmmd/cli.py
@@ -1,0 +1,24 @@
+"""Command-line interface."""
+
+import click
+
+
+@click.group()
+def rmmd():
+    """RMMD CLI main function."""
+    pass
+
+
+@rmmd.command("validate")
+@click.argument("model_file")
+@click.option(
+    "-o",
+    "--option",
+    default=0,
+    show_default=True,
+    help="This is a dummy option to show how to add them with click.",
+)
+def validate(model_file: str, option: int):
+    """Validate MODEL_FILE against RMMD schema."""
+    print(f"You requested to validate {model_file}...")
+    print(f"Option value: {option}")


### PR DESCRIPTION
This adds a basic starter CLI with the following commands. To use it, first update your local environment by running `pixi install`. You can run `which rmmd` to check that it worked. Then you can try the following:
```
# prints help message:
rmmd

# also prints help message:
rmmd --help

# prints subcommand help message:
rmmd validate --help

# runs subcommand with argument `file.yaml`:
rmmd validate file.yaml

# runs subcommand with argument `file.yaml`, passing a dummy option:
rmmd validate file.yaml -o 5
```